### PR TITLE
description property of sequence raw_input does not exist

### DIFF
--- a/abstar/utils/output.py
+++ b/abstar/utils/output.py
@@ -185,7 +185,6 @@ class AbstarResult(object):
 
         output = collections.OrderedDict([
             ('seq_id', self.antibody.id),
-            ('description', self.antibody.raw_input.description),
             ('uid', self.antibody.uid),
             ('uaid', self.antibody.uid),
             ('chain', self.antibody.chain),


### PR DESCRIPTION
This causes abstar to fail to identify any rearrangements in data sets, both the abstar test data and the eodGT8 test data. 
Removing self.antibody.raw_input.description resolves this.